### PR TITLE
Removes obsolete second parameter in call to getGridFS

### DIFF
--- a/src/Purekid/Mongodm/MongoDB.php
+++ b/src/Purekid/Mongodm/MongoDB.php
@@ -337,7 +337,7 @@ class MongoDB
 
 	/* File management */
 
-	public function gridFS( $arg1 = NULL, $arg2 = NULL)
+	public function gridFS($arg1 = NULL)
 	{
 		try{
 			$this->_connected OR $this->connect();
@@ -352,12 +352,7 @@ class MongoDB
 			: 'fs';
 		}
 
-		if ( ! isset($arg2) && isset($this->_config['gridFS']['arg2']))
-		{
-			$arg2 = $this->_config['gridFS']['arg2'];
-		}
-
-		return $this->_db->getGridFS($arg1,$arg2);
+		return $this->_db->getGridFS($arg1);
 	}
 
 	public function get_file(array $criteria = array())

--- a/tests/GridFsTest.php
+++ b/tests/GridFsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use Purekid\Mongodm\MongoDB;
+
+class GridFsTest extends PHPUnit_Framework_TestCase
+{
+    public function getGridFSPrefixes()
+    {
+        return array(
+            array(null),
+            array('files-')
+        );
+    }
+
+    /**
+    * @dataProvider getGridFSPrefixes
+    */
+    public function testGetGridFs($prefix)
+    {
+        $mongo_db = MongoDB::instance();
+        $grid_fs = $mongo_db->gridFs($prefix);
+        $this->assertInstanceOf('MongoGridFS', $grid_fs);
+    }
+}


### PR DESCRIPTION
I've updated the MongoDB::gridFS() method to match the updated version to the mongo-php-driver. 
See this for details on the library change https://github.com/mongodb/mongo-php-driver/pull/435
