### PR TITLE
Add mutate method to model

### DIFF
--- a/src/Purekid/Mongodm/Model.php
+++ b/src/Purekid/Mongodm/Model.php
@@ -83,6 +83,31 @@ abstract class Model
 		}
 		return true;
 	}
+
+	/**
+	 * Mutate data by direct query
+	 * @param array $updateQuery
+	 * @return boolean
+	 */
+	public function mutate($updateQuery, $options = array())
+	{
+		if(!is_array($updateQuery)) throw new Exception('$updateQuery should be an array');
+		if(!is_array($options)) throw new Exception('$options should be an array');
+
+		$default = array(
+			'w' => 1
+		);
+		$options = array_merge($default, $options);
+
+		try {
+			$this->_connection->update($this->collectionName(), array('_id' => $this->cleanData['_id']), $updateQuery, $options);
+		}
+		catch(\MongoCursorException $e) {
+			return false;
+		}
+
+		return true;
+	}
 	
 	/**
 	 * get MongoId of this record

--- a/tests/MutatorTest.php
+++ b/tests/MutatorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Purekid\Mongodm\Test\Model\Book;
+use Purekid\Mongodm\Test\Model\User;
+use Purekid\Mongodm\Collection;
+
+class MutatorTest extends PHPUnit_Framework_TestCase {
+  
+  public function testMutate(){
+    
+    $user = User::one();
+    $id = $user->getId();
+    $age = $user->age;
+
+    $user->mutate(array('$inc' => array('age' => 1)));
+    
+    $user = User::id($id);
+    $this->assertEquals($age + 1, $user->age);
+    
+  }
+  
+  public function testMutateFail(){
+    
+    $user = User::one();
+    $id = $user->getId();
+    $age = $user->age;
+
+    $fail = $user->mutate(array('$set' => array('ages' => array('$inc' => 1))));
+    
+    $this->assertFalse($fail);
+    
+  }
+  
+}


### PR DESCRIPTION
Add ability to mutate the data directly (i.e. use `$inc` and other MongoDB operators.) This protects data from loss where find -> mutate -> save would lose any transactions in between requests.

``` php
    // {... age: 16 ...}
    user = User::one();
    $id = $user->getId();
    $age = $user->age;

    $user->mutate(array('$inc' => array('age' => 1)));
    // {... age: 17 ...}
```

This could have serious effects such as:

``` php
    // {... age: 16 ...}
    $user->mutate(array('age' => 1));
    // { age: 16 }
```
