### PR TITLE
Add `date` type which maps to `MongoDate` and refactor `parseValues`

### DIFF
--- a/src/Purekid/Mongodm/Exception/InvalidDataTypeException.php
+++ b/src/Purekid/Mongodm/Exception/InvalidDataTypeException.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Purekid\Mongodm\Exception;
+
+class InvalidDataTypeException extends \Exception {} 

--- a/tests/Model/DataType.php
+++ b/tests/Model/DataType.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Purekid\Mongodm\Test\Model;
+
+class DataType extends Base
+{
+
+  static $collection = "dataType";
+
+  protected static $attrs = array(
+    \Purekid\Mongodm\Model::DATA_TYPE_ARRAY      => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_ARRAY,      'default'=>array(1,2,3)),
+    \Purekid\Mongodm\Model::DATA_TYPE_BOOLEAN    => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_BOOLEAN,    'default'=>true),
+    \Purekid\Mongodm\Model::DATA_TYPE_DATE       => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_DATE,       'default'=>"now"),
+    \Purekid\Mongodm\Model::DATA_TYPE_DOUBLE     => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_DOUBLE,     'default'=>1.2345),
+    \Purekid\Mongodm\Model::DATA_TYPE_EMBED      => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_EMBED,      'model'=>'Purekid\Mongodm\Test\Model\Embed'),
+    \Purekid\Mongodm\Model::DATA_TYPE_EMBEDS     => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_EMBEDS,     'model'=>'Purekid\Mongodm\Test\Model\Embed'),
+    \Purekid\Mongodm\Model::DATA_TYPE_INT        => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_INT,        'default'=>123),
+    \Purekid\Mongodm\Model::DATA_TYPE_INTEGER    => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_INTEGER,    'default'=>456),
+    \Purekid\Mongodm\Model::DATA_TYPE_MIXED      => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_MIXED,      'default'=>array(1,'a',array('b'=>'B'))),
+    \Purekid\Mongodm\Model::DATA_TYPE_REFERENCE  => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_REFERENCE,  'model'=>'Purekid\Mongodm\Test\Model\Refernece'),
+    \Purekid\Mongodm\Model::DATA_TYPE_REFERENCES => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_REFERENCES, 'model'=>'Purekid\Mongodm\Test\Model\Reference'),
+    \Purekid\Mongodm\Model::DATA_TYPE_STRING     => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_STRING,     'default'=>'string'),
+    \Purekid\Mongodm\Model::DATA_TYPE_TIMESTAMP  => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_TIMESTAMP,  'default'=>0),
+    \Purekid\Mongodm\Model::DATA_TYPE_OBJECT     => array('type'=>\Purekid\Mongodm\Model::DATA_TYPE_OBJECT,     'default'=>array('a' => 'A')),
+    'invalid'                                    => array('type'=>'invalid')
+  );
+  
+}

--- a/tests/Model/DataTypeEmbed.php
+++ b/tests/Model/DataTypeEmbed.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Purekid\Mongodm\Test\Model;
+
+class DataTypeEmbed extends Base
+{
+
+  static $collection = "DataTypeEmbed";
+
+}

--- a/tests/Model/DataTypeReference.php
+++ b/tests/Model/DataTypeReference.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Purekid\Mongodm\Test\Model;
+
+class DataTypeReferenece extends Base
+{
+
+  static $collection = "DataTypeReferenece";
+
+}

--- a/tests/ParseValueTest.php
+++ b/tests/ParseValueTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Purekid\Mongodm\Test;
+
+class ParseValueTest extends \Purekid\Mongodm\Test\TestCase\PhactoryTestCase {
+
+  public $model;
+
+  public function __construct() {
+    $this->model = new \Purekid\Mongodm\Test\Model\DataType();
+  }
+
+  public function testArray() {
+    $data = array(1,2,3);
+    $actual = $this->model->parseValue('array', $data);
+    $this->assertInternalType('array', $actual);
+    
+    $this->setExpectedException('\Purekid\Mongodm\Exception\InvalidDataTypeException');
+    $data = 1;
+    $actual = $this->model->parseValue('array', $data);
+  }
+
+  public function testInteger() {
+    $data = 1;
+    $actual = $this->model->parseValue('int', $data);
+    $this->assertInternalType('integer', $actual);
+    
+    $data = 2.1;
+    $actual = $this->model->parseValue('integer', $data);
+    $this->assertInternalType('integer', $actual);
+  }
+
+  public function testString() {
+    $data = 'string';
+    $actual = $this->model->parseValue('string', $data);
+    $this->assertInternalType('string', $actual);
+
+    $data = 1;
+    $actual = $this->model->parseValue('string', $data);
+    $this->assertInternalType('string', $actual);
+  }
+
+  public function testDouble() {
+    $data = 1.23456;
+    $actual = $this->model->parseValue('double', $data);
+    $this->assertInternalType('float', $actual);
+
+    $data = '1.23456';
+    $actual = $this->model->parseValue('double', $data);
+    $this->assertInternalType('float', $actual);
+  }
+
+  public function testTimestamp() {
+    $data = time();
+    $actual = $this->model->parseValue('timestamp', $data);
+    $this->assertInstanceOf('\MongoTimestamp', $actual);
+
+    $this->setExpectedException('\Purekid\Mongodm\Exception\InvalidDataTypeException');
+    $data = 'today';
+    $actual = $this->model->parseValue('timestamp', $data);
+  }
+
+  public function testDate() {
+    $data = time();
+    $actual = $this->model->parseValue('date', $data);
+    $this->assertInstanceOf('\MongoDate', $actual);
+
+    $data = 'today';
+    $actual = $this->model->parseValue('date', $data);
+    $this->assertInstanceOf('\MongoDate', $actual);
+
+    $data = new \DateTime();
+    $actual = $this->model->parseValue('date', $data);
+    $this->assertInstanceOf('\MongoDate', $actual);
+
+    $this->setExpectedException('\Purekid\Mongodm\Exception\InvalidDataTypeException');
+    $data = 'a random string';
+    $actual = $this->model->parseValue('date', $data);
+  }
+
+  public function testBool() {
+    $data = true;
+    $actual = $this->model->parseValue('boolean', $data);
+    $this->assertInternalType('boolean', $actual);
+
+    $data = 'false';
+    $actual = $this->model->parseValue('boolean', $data);
+    $this->assertInternalType('boolean', $actual);
+  }
+
+  public function testObject() {
+    $data = new \StdClass();
+    $actual = $this->model->parseValue('object', $data);
+    $this->assertInternalType('object', $actual);
+
+    $data = array('a' => 'A', 1);
+    $actual = $this->model->parseValue('object', $data);
+    $this->assertInternalType('object', $actual);
+  }
+
+  public function testOtherValidTypes() {
+    $data = null;
+    $actual = $this->model->parseValue('mixed', $data);
+    $this->assertInternalType('null', $actual);
+
+    $actual = $this->model->parseValue('embed', $data);
+    $this->assertInternalType('null', $actual);
+    $actual = $this->model->parseValue('embeds', $data);
+    $this->assertInternalType('null', $actual);
+
+    $actual = $this->model->parseValue('reference', $data);
+    $this->assertInternalType('null', $actual);
+    $actual = $this->model->parseValue('references', $data);
+    $this->assertInternalType('null', $actual);
+  }
+
+  public function testInvalidType() { 
+    $this->setExpectedException('\Purekid\Mongodm\Exception\InvalidDataTypeException');
+    $this->model->parseValue('invalid', null);
+  }
+
+}


### PR DESCRIPTION
I believe that you are actually wanting `date` rather than `timestamp`.

> **MongoTimestamp is used by sharding**. If you're not looking to write sharding tools, what you probably want is MongoDate.
> 
> MongoTimestamp is 4 bytes of timestamp (seconds since the epoch) and 4 bytes of increment.
> 
> **This class is not for measuring time, creating a timestamp on a document or automatically adding or updating a timestamp on a document. Unless you are writing something that interacts with the sharding internals, stop, go directly to MongoDate, do not pass go, do not collect 200 dollars. _This is not the class you are looking for._**

I also refactored `parseValues` to better support the aliases as well as removing unnecessary conditionals. 
