### PR TITLE
Removes string type hint as there is no string class

### DIFF
--- a/src/Purekid/Mongodm/MongoDB.php
+++ b/src/Purekid/Mongodm/MongoDB.php
@@ -247,7 +247,7 @@ class MongoDB
 
 	/* Collection management */
 
-	public function create_collection ( string $name, $capped= FALSE, $size= 0, $max= 0 )
+	public function create_collection ( $name, $capped= FALSE, $size= 0, $max= 0 )
 	{
 		return $this->_call('create_collection', array(
 				'name'    => $name,


### PR DESCRIPTION
The create_collection() in MongoDB had a string type hint for the $name parameter but there is no string class.
