### PR TITLE
Fix "fieldname is not instance of 'Models\XXXXX'" error

### DIFF
--- a/src/Purekid/Mongodm/Model.php
+++ b/src/Purekid/Mongodm/Model.php
@@ -1016,6 +1016,10 @@ abstract class Model
                 $return  = $value->toArray(array('_type','_id'));
             } elseif ($value === null) {
                 $return = null;
+            } elseif (isset($value, $value['$ref'], $value['$id'])) {
+                $value = $model::id($value['$id']);
+                $ref = $value->makeRef();
+                $return = $ref;
             } else {
                 throw new \Exception("{$key} is not instance of '$model'");
             }


### PR DESCRIPTION
When your model has references 

``` php
protected static $attrs = array(
    'number' => array('type' => 'integer'),
    'fieldname' => array('model'=>'Models\Somemodel','type'=>'reference')
);
```

You may face some exceptions when you try to do smth like this:

``` php
$obj = new Somemodel::id(...);
$data = $obj->toArray();
$data['number']++; 
$obj->update($data);
```

This PR should fix it
