### PR TITLE
Fixed authenticate() deprecation warning and updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,16 @@ Database config file  (By default it locates at /vendor/purekid/mongodm/config.p
     	)
     );
 ```
+#### Authentication
+Authentication information is passed in via the options array.  If you do not specifiy authSource, then the PHP Mongo Driver will choose the "admin" database.
+
+```
+$config =  array( 'connection' => array(
+      'hostnames' => '<host>:<port>',
+      'database'  => '<databasename>',
+      'options'  => [ "connectTimeoutMS" => 500 , "username" => "admin", "password" => "<password>", "authSource" => "admin"] )
+  );
+```
 
 ### Setup database in application
 

--- a/src/Purekid/Mongodm/MongoDB.php
+++ b/src/Purekid/Mongodm/MongoDB.php
@@ -200,12 +200,6 @@ class MongoDB
             throw new \Exception('Unable to connect to database :: $_db is ' . gettype($this->_db));
         }
         
-        if (isset($config['options']['username']) && isset($config['options']['password'])) {
-            $this->_db->authenticate($config['options']['username'], $config['options']['password']);
-        } elseif (isset($config['username']) && isset($config['password'])) {
-            $this->_db->authenticate($config['username'], $config['password']);
-        }
-
         $this->_connected = true;
 
         return true;


### PR DESCRIPTION
'PHP Deprecated:  Function MongoDB::authenticate() is deprecated in ./vendor/purekid/mongodm/src/Purekid/Mongodm/MongoDB.php on line 204'

I have also updated README.md to provide an example of how to get authentication working.